### PR TITLE
Replaced an explicit loop with a a replace().

### DIFF
--- a/include/queryFromBrowser.js
+++ b/include/queryFromBrowser.js
@@ -1,17 +1,16 @@
 @ global: request @
 
 @once@
-	var query = 
+	var query =
 		@@@ if( request && request.query ) { @@@
 			@= request.query @
 		@@@ } else { @@@
 			(function( s ) {
-				var r = {},
-					splittedParams = s.split('&');
-				for (var i = 0, e = splittedParams[i]; i < splittedParams.length; i++, e = splittedParams[i]) {
-					e = e.split('=');
-					r[e[0]] = e[1] || "";
-				}
+				var r = {};
+				s.replace( /([^=&]+)(=?)([^&]*)/g, function( _1, key, _2, value ){
+					r[key] = value;
+					return "";
+				} );
 				return r;
 			})( window.location.search.substr( 1 ) )
 		@@@ } @@@


### PR DESCRIPTION
I am not sure we need an IIFE around it. Just to hide `r`? I don't have enough knowledge of internals to make a call.

Another thing is a slight functional difference between the old code and the new one. The old one, when faced with a string like that: `"a=1=2"`, will create an entry with key `"a"`, and value `"1"`, while the new one will create an entry with key `"a"`, and value `"1=2"`. Granted, the whole case is a pathological one, and I hope it never happens, yet there is a difference. I think that the new way to handle it is more correct than the old one.
